### PR TITLE
fix: unify numeric slugs in web-linked gallery grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- Web‑linked gallery now correctly groups pages with purely numeric slugs (e.g., `00.html` … `14.html`). The `normalizeGallerySlug()` helper returns a fixed token (`"numeric"`) when the normalized base is empty and the original slug consists only of digits, allowing `isSameGalleryStructure` to recognise all numeric‑only pages as part of the same sequence. This resolves the "No dominant image group found" error and restores the expected tab‑opening flow. ([#73](https://github.com/del-Pacifico/Mass-Image-Downloader/issues/73))
+
+---
+
 ## [2.8.186] - 2026-06-02
 
 ### Fixed

--- a/scripts/extractWebLinkedGallery.js
+++ b/scripts/extractWebLinkedGallery.js
@@ -377,11 +377,15 @@
      * - "patritcy-00.html" -> "patritcy"
      * - "gallery_01.php"   -> "gallery"
      * - "set123-004.asp"   -> "set123"
+     * - "00.html"          -> "numeric"  // ✅ NEW: unified token
+     * - "01.html"          -> "numeric"  // ✅ NEW: unified token
      * @param {string} segment - Raw last path segment.
      * @returns {string} A normalized slug base used for structural comparison.
      */
     function normalizeGallerySlug(segment) {
         try {
+
+            // ✅ Normalize case and trim whitespace
             const safeSegment = String(segment || "").toLowerCase().trim();
 
             if (!safeSegment) return "";
@@ -403,7 +407,16 @@
                 .replace(/^-+|-+$/g, "")
                 .trim();
 
+            // ✅ FIX Bug#73: If the normalized base is empty and the original slug was purely numeric,
+            // return a fixed token so all numeric slugs share the same base.
+            if (!normalized && /^\d+$/.test(noExt)) {
+                return "numeric";
+            }
+
+            // Fallback: if normalized is empty but noExt has content (e.g., "00" is numeric),
+            // we already handled it above. For safety, keep the original fallback.
             return normalized || noExt || cleanSegment;
+            
         } catch (err) {
             logDebug(2, `⚠️ Failed to normalize gallery slug: ${err.message}`);
             return "";


### PR DESCRIPTION
# 🏔️ Mass Image Downloader – Pull Request

---

## 📋 Summary

This PR fixes a grouping failure in the **Web‑linked Gallery** flow when page slugs are purely numeric (e.g., `00.html` … `14.html`).  

The root cause was that `normalizeGallerySlug()` returned distinct values (`"00"`, `"01"`, etc.) for each numeric slug, preventing `isSameGalleryStructure()` from recognising them as part of the same sequence. The fix introduces a **fixed token** (`"numeric"`) when the normalized base is empty and the original slug consists only of digits. This allows all numeric‑only pages to share the same base, enabling structural grouping and restoring the expected tab‑opening flow.

No other modules or flows are affected.

---

## 🔧 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement (non-breaking improvement)
- [ ] Code refactor (no behavior change)
- [ ] Documentation update
- [ ] Build/CI/Repo tooling
- [ ] Other (please describe):

---

## 🧪 Related Issues

**Closes #73** – [Bug] Web‑linked gallery fails to group numeric page slugs (e.g., 00.html – 14.html)

---

## 🧭 Branch Flow & Labels

- **Target branch:** `dev`
- **Source branch:** `fix/web-linked-numeric-slug-grouping`
- **Required labels:**
  - `type: bug`
  - `scope: web-linked-galleries`
  - `priority: high`
  - `status: ready-for-qa` (or `status: qa-approved` after review)

---

## 🎯 Scope & Impact

- **User-facing change?**
  - [x] Yes
  - [ ] No

- **Affected modules/features:**
  - Web‑linked Gallery extraction (`extractWebLinkedGallery.js`)
  - `normalizeGallerySlug()` helper function

- **Expected behavior change:**
  - Pages with purely numeric slugs (e.g., `00.html` … `14.html`) are now correctly grouped into a single dominant group.
  - The flow proceeds to open tabs for all grouped pages instead of aborting with *“No dominant image group found”*.
  - Mixed slugs (`patritcy-00.html` … `patritcy-14.html`) remain unchanged.

---

## ⚠️ Risk Assessment

- **Risk level:**
  - [x] Low
  - [ ] Medium
  - [ ] High

- **Potential blast radius:**
  - Only affects the `normalizeGallerySlug()` function.
  - The new branch only executes when the normalized base is empty **and** the slug consists purely of digits.
  - Mixed slugs (with descriptive prefixes) never reach this branch.
  - No changes to URL validation, gallery heuristics, download naming, hotkey assignments, MV3 recovery paths, or other modules.

- **Rollback plan:**
  - Revert the commit and reopen the issue if any regression is detected.
  - The change is fully backward‑compatible; existing galleries with descriptive slugs continue to work exactly as before.

---

## ✅ Testing Performed

**Automated checks:**

- [x] `npm run check` – passed
- [x] `npm test` – passed (3 tests, 3 pass)

**Browsers tested:**

- [x] Brave: `1.91.171` (Official Build) (64‑bit) – Chromium `149.0.7827.103`
- [ ] Edge (Chromium): `version`
- [ ] Chrome: `version`
- [ ] Other Chromium: `version`

**Steps verified:**

1. Created a local test page with 15 links: `00.html` … `14.html` (each with an `<img>` placeholder).
2. Triggered Web‑linked Gallery hotkey (`Alt+Shift+W`) on the test page.
3. Verified console logs show dominant group size = `15` and similarity score ≥ `90%`.
4. Confirmed 15 tabs opened successfully.
5. Tested mixed gallery (`patritcy-00.html` … `patritcy-14.html`) – group size `15`, base `"patritcy"` (unchanged).
6. Tested single numeric page on a non‑gallery page – no false‑positive group (filter and minimum group size check prevent it).
7. Verified other gallery modes (visual, linked, bulk) remain unaffected.

---

## 📸 Screenshots / Recordings (if applicable)

*Console log excerpt after fix:*

```text
🧪 Similarity diagnostics → dirMatch=true, exactBase=true, final=90.0%
🎯 Dominant group size: 15
📤 Sending 15 grouped web-linked gallery URLs to background.
```

---

## 🧾 Documentation & Changelog (Required when user-facing)
- [ ] Documentation updated (README / docs/ manuals) if behavior, UI, or settings changed
- [X] **CHANGELOG.md updated** for any user-facing change (this is required)
- [ ] No documentation/changelog needed (refactor/tooling only)

---

## ✅ Checklist

- [X] This PR targets `dev` and follows `feature/chore branch -> dev -> main -> tag/release`
- [X] Required repository labels were assigned (`type:*`, `scope:*`, and lifecycle/impact labels as applicable)
- [X] The code follows the project’s style guide
- [X] Local compliance checks pass, or any skipped checks are explained
- [X] Changes are modular, focused, and testable
- [X] Error handling and edge cases were considered, with clear logs or user-facing messages where appropriate
- [X] CPU, memory, filesystem, and batch-processing impact were considered
- [X] Code comments, logs, and user-facing messages use professional, approachable English
- [X] I’ve tested this functionality locally in a supported browser
- [X] I’ve reviewed and updated documentation where applicable
- [X] I’ve added or adjusted relevant logging/debug output (no sensitive data)
- [X] I’ve confirmed that no sensitive information is exposed in this PR
- [X] MV3-friendly: no leaking listeners/timers; resources cleaned up appropriately (if relevant)

---

## 🔍 Additional Context

This fix was discussed and validated in issue #73. Full QA trace, test environment details, and console logs are available in the issue comments.

Reviewer: @sergiopalmah

> For architecture, manuals, and configuration guidance, please refer to the `docs/` folder.
> For user-facing changes, `CHANGELOG.md` is the source of truth.
